### PR TITLE
feat: add mvp backend and frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+apps/*/node_modules
+apps/*/dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # makingbaby
-this will have sideby and small wins together
+
+Starter monorepo combining a simple backend and frontend for the MakingBaby MVP.
+
+## Development
+
+Install dependencies:
+
+```
+npm install
+```
+
+Build both apps:
+
+```
+npm run build
+```
+
+Run backend:
+
+```
+npm run dev -w backend
+```
+
+Run frontend:
+
+```
+npm run dev -w frontend
+```

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "backend",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "echo \"No backend tests\""
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/api/hello', (_req, res) => {
+  res.json({ message: 'Hello from backend' });
+});
+
+app.listen(port, () => {
+  console.log(`Backend listening on port ${port}`);
+});

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MakingBaby MVP</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No frontend tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.12",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export default function App() {
+  const [message, setMessage] = useState('Loading...');
+
+  useEffect(() => {
+    fetch('/api/hello')
+      .then((res) => res.json())
+      .then((data) => setMessage(data.message))
+      .catch(() => setMessage('Error fetching message'));
+  }, []);
+
+  return <h1>{message}</h1>;
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "makingbaby",
+  "private": true,
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "build": "npm run build -w backend && npm run build -w frontend",
+    "test": "npm test -w backend && npm test -w frontend"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold npm workspace monorepo with backend and frontend apps
- add express backend with example `/api/hello` route
- add React frontend via Vite that fetches hello message from backend

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden fetching @types/express)*
- `npm run build` *(fails: tsc command not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_b_6896d40437008323bce55a9afb92227b