### PR TITLE
feat(backend): add jwt auth endpoints

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { LoginDto } from './dto/login.dto';
+import { CreateUserDto } from '../user/dto/create-user.dto';
+import { createUser, findUserByEmail, verifyPassword } from '../user/user.service';
+import { generateToken } from './auth.service';
+
+const router = Router();
+
+router.post('/register', async (req, res) => {
+  const dto: CreateUserDto = req.body;
+  if (findUserByEmail(dto.email)) {
+    return res.status(400).json({ message: 'User already exists' });
+  }
+  const user = await createUser(dto);
+  const token = generateToken(user);
+  res.json({ token });
+});
+
+router.post('/login', async (req, res) => {
+  const dto: LoginDto = req.body;
+  const user = findUserByEmail(dto.email);
+  if (!user || !verifyPassword(dto.password, user.password)) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  const token = generateToken(user);
+  res.json({ token });
+});
+
+export default router;

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,0 +1,23 @@
+import crypto from 'crypto';
+import { User } from '../user/user.service';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+function base64url(input: string | Buffer): string {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+export function generateToken(user: User): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(
+    JSON.stringify({ sub: user.email, iat: Math.floor(Date.now() / 1000) })
+  );
+  const signature = base64url(
+    crypto.createHmac('sha256', JWT_SECRET).update(`${header}.${payload}`).digest()
+  );
+  return `${header}.${payload}.${signature}`;
+}

--- a/apps/backend/src/auth/dto/login.dto.ts
+++ b/apps/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,4 @@
+export interface LoginDto {
+  email: string;
+  password: string;
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,7 +1,11 @@
 import express from 'express';
+import authRouter from './auth/auth.controller';
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/auth', authRouter);
 
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from backend' });

--- a/apps/backend/src/user/dto/create-user.dto.ts
+++ b/apps/backend/src/user/dto/create-user.dto.ts
@@ -1,0 +1,5 @@
+export interface CreateUserDto {
+  email: string;
+  password: string;
+  fullName: string;
+}

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -1,0 +1,32 @@
+import crypto from 'crypto';
+import { CreateUserDto } from './dto/create-user.dto';
+
+export interface User {
+  email: string;
+  password: string;
+  fullName: string;
+}
+
+const users: User[] = [];
+
+function hashPassword(password: string): string {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export async function createUser(dto: CreateUserDto): Promise<User> {
+  const user: User = {
+    email: dto.email,
+    password: hashPassword(dto.password),
+    fullName: dto.fullName,
+  };
+  users.push(user);
+  return user;
+}
+
+export function findUserByEmail(email: string): User | undefined {
+  return users.find((u) => u.email === email);
+}
+
+export function verifyPassword(password: string, hash: string): boolean {
+  return hashPassword(password) === hash;
+}


### PR DESCRIPTION
## Summary
- copy auth and user modules into backend and adapt to Express
- add in-memory user service with SHA256 password hashing
- expose `/auth/register` and `/auth/login` endpoints that issue JWT tokens

## Testing
- `npm --prefix apps/backend test`
- `npm --prefix apps/backend run build`


------
https://chatgpt.com/codex/tasks/task_b_6896da29bcec83238a6f1134227a80cc