### PR TITLE
feat: connect backend to MongoDB with shared schemas

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,10 @@
     "test": "echo \"No backend tests\""
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "dotenv": "^16.3.1",
+    "mongoose": "^7.6.3",
+    "@nestjs/mongoose": "^10.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -1,0 +1,10 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const config = {
+  port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
+  mongoUri: process.env.MONGO_URI || 'mongodb://localhost:27017/makingbaby',
+};
+
+export default config;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,7 +1,20 @@
 import express from 'express';
+import mongoose from 'mongoose';
+import { config } from './config';
+
+// Reuse compiled schemas from the existing NestJS app
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { UserSchema } = require('../../babymakin/app-master/dist/user/entities/user.entity.js');
+
+mongoose
+  .connect(config.mongoUri)
+  .then(() => console.log('Connected to MongoDB'))
+  .catch((err: unknown) => console.error('MongoDB connection error:', err));
+
+mongoose.model('User', UserSchema);
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = config.port;
 
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from backend' });


### PR DESCRIPTION
## Summary
- configure backend with environment-driven settings
- connect to MongoDB and load schemas from existing NestJS app
- add Mongo/Mongoose dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896da2fc57c83238eb70999b85a8449