### PR TITLE
feat: add auth validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,23 @@ Run frontend:
 ```
 npm run dev -w frontend
 ```
+
+## Testing
+
+Run all tests:
+
+```
+npm test
+```
+
+Run backend tests:
+
+```
+npm test -w backend
+```
+
+Run frontend tests:
+
+```
+npm test -w frontend
+```

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -3,6 +3,21 @@ import express from 'express';
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body ?? {};
+  if (typeof username !== 'string' || username.trim() === '' || typeof password !== 'string' || password.trim() === '') {
+    return res.status(400).json({ message: 'Invalid payload' });
+  }
+
+  if (username === 'admin' && password === 'password') {
+    return res.json({ message: 'Login successful' });
+  }
+
+  res.status(401).json({ message: 'Invalid credentials' });
+});
+
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from backend' });
 });

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "echo \"No frontend tests\""
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -16,7 +16,12 @@
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.12",
     "@vitejs/plugin-react": "^4.0.0",
+    "jsdom": "^22.1.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import LoginForm from './LoginForm';
 
 export default function App() {
   const [message, setMessage] = useState('Loading...');
@@ -10,5 +11,10 @@ export default function App() {
       .catch(() => setMessage('Error fetching message'));
   }, []);
 
-  return <h1>{message}</h1>;
+  return (
+    <>
+      <h1>{message}</h1>
+      <LoginForm />
+    </>
+  );
 }

--- a/apps/frontend/src/LoginForm.test.tsx
+++ b/apps/frontend/src/LoginForm.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginForm from './LoginForm';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+test('allows user to login', async () => {
+  const user = userEvent.setup();
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({ message: 'Login successful' })
+  } as Response);
+
+  render(<LoginForm />);
+
+  await user.type(screen.getByPlaceholderText(/username/i), 'admin');
+  await user.type(screen.getByPlaceholderText(/password/i), 'password');
+  await user.click(screen.getByRole('button', { name: /login/i }));
+
+  expect(await screen.findByText(/logged in/i)).toBeInTheDocument();
+});

--- a/apps/frontend/src/LoginForm.tsx
+++ b/apps/frontend/src/LoginForm.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export default function LoginForm() {
+  const [status, setStatus] = useState<string>('');
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = {
+      username: (form.elements.namedItem('username') as HTMLInputElement).value,
+      password: (form.elements.namedItem('password') as HTMLInputElement).value
+    };
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    setStatus(res.ok ? 'success' : 'error');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="username" placeholder="Username" />
+      <input name="password" type="password" placeholder="Password" />
+      <button type="submit">Login</button>
+      {status === 'success' && <p>Logged in</p>}
+      {status === 'error' && <p>Login failed</p>}
+    </form>
+  );
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -7,5 +7,8 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:3000'
     }
+  },
+  test: {
+    environment: 'jsdom'
   }
 });


### PR DESCRIPTION
## Summary
- add login endpoint with request validation
- create login form with smoke test
- document test commands

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896da449aac8323a71a7fb49cea2d69