### PR TITLE
Add dev script and deployment templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Simple Dockerfile to build and run the backend
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+COPY apps/backend/package*.json apps/backend/
+COPY apps/frontend/package*.json apps/frontend/
+RUN npm install --workspaces
+COPY . .
+RUN npm run build -w backend
+EXPOSE 3000
+CMD ["node", "apps/backend/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,37 @@ Run frontend:
 ```
 npm run dev -w frontend
 ```
+
+Run both apps concurrently:
+
+```
+npm run dev
+```
+
+## Environment Variables
+
+Example `.env.example` files are provided for the backend and frontend.
+Copy them to `.env` in each app and adjust as needed.
+
+## Deployment
+
+### Docker
+
+Build and run the backend with Docker:
+
+```
+docker build -t makingbaby-backend .
+docker run -p 3000:3000 makingbaby-backend
+```
+
+### Vercel
+
+Deploy the frontend using the provided `vercel.json`:
+
+```
+vercel --prod apps/frontend
+```
+
+### Render
+
+The `render.yaml` config demonstrates how to deploy the backend on Render.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,2 @@
+# Backend environment variables
+PORT=3000

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,2 @@
+# Frontend environment variables
+VITE_API_URL=http://localhost:3000

--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }],
+  "routes": [{ "src": "/(.*)", "dest": "/" }]
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,11 +1,14 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      '/api': 'http://localhost:3000'
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': env.VITE_API_URL || 'http://localhost:3000'
+      }
     }
-  }
+  };
 });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": ["apps/*"],
   "scripts": {
     "build": "npm run build -w backend && npm run build -w frontend",
-    "test": "npm test -w backend && npm test -w frontend"
+    "test": "npm test -w backend && npm test -w frontend",
+    "dev": "npm run dev -w backend & npm run dev -w frontend & wait"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: makingbaby-backend
+    env: node
+    plan: free
+    buildCommand: npm install && npm run build -w backend
+    startCommand: node apps/backend/dist/index.js
+    envVars:
+      - key: PORT
+        value: 3000


### PR DESCRIPTION
## Summary
- run backend and frontend concurrently via new root `npm run dev`
- document environment variables with example `.env.example` files
- add Docker/Vercel/Render deployment templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896da46a7d0832391e06ab52ddc9f75